### PR TITLE
Remove utils.dump() to fix Lua error

### DIFF
--- a/lua/hop-extensions/utils.lua
+++ b/lua/hop-extensions/utils.lua
@@ -68,7 +68,6 @@ function M.filter_window(node, contexts, nodes_set)
 	for key, value in pairs(node) do
 		n[key] = value
 	end
-	utils.dump(nodes_set[line .. column], n)
 	nodes_set[line .. column] = n
 end
 


### PR DESCRIPTION
I believe the `utils.dump()` is a debug function to be deleted before release, but missed. Remove the function call should fix the Lua error complaining about "attempt to index global 'utils' (a nil value)".